### PR TITLE
(e-book) Figure 1.15 undersampling, jpeg-ification

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Errors are listed by chapter, followed by page number.
 
 Page 35: Figure 1.13 is incorrectly labeled a Mercator projection.  It's actually an Equirectangular projection (also known in WCS as a "Cartesian projection")
 
+Page 38 (e-book): Figure 1.15, particularly the bottom subfigure, is very undersampled and jpeg-ified; as a result, the CMB map doesn't illustrate the level of detail available at HEALPix Nside=512 resolution.
+
 ## Chapter 2
 
 Page 60: Eq. (2.7) less than sign should be greater than??


### PR DESCRIPTION
In the e-book, I noticed some major undersampling and jpeg-ification of Figure 1.15. These adverse features show up independent of browser, and also when I print the relevant page to [PDF](http://faun.rc.fas.harvard.edu/ameisner/fig1_15.pdf). This leaves the CMB image short of conveying the Nside=512 resolution mentioned in the caption, even though the resolution is captured much more successfully in the "plate 3" color version of the figure. Thanks!
