### PR TITLE
Typo on Page 95- 'Cauchy" instead of 'Laplace'

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ Page 339: Typo on line 7, "that" should be replaced by "than" in the sentence
 
 Page 357: In Equation 8.77 and 8.78 the term in square brackets should be squared. 
 
-Page 357: In Equation 8.77 and 8.78 the term in square brackets should be squared. 
-
 ## Chapter 9
 
 


### PR DESCRIPTION
Minor typo, I think.  Once again I've managed to edit the readme in two commits rather than one.
