### PR TITLE
Possible swapping of the word "heteroscedastic" with "homoscedastic" on page 329.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ to the data before computing the periodogram.  See a more detailed discussion al
 with an updated figure on the
 [astroML website](http://www.astroml.org/book_figures/chapter10/fig_LS_sg_comparison.html)
 
-
+Page 444: Equation 10.76- should probably be phi_m = atan(b_m/a_m) instead of phi_m = atan(b_m,a_m)
 
 ## Appendix
 

--- a/README.md
+++ b/README.md
@@ -70,13 +70,8 @@ Page 234: In the sample Python code, the sigma in the pymc.Normal command should
 
 ## Chapter 8
 
-<<<<<<< HEAD
-Page 339: Typo on line 7, "...the bandwidth is more important that the exact shape..."
-=======
 Page 339: Typo on line 7, "that" should be replaced by "than" in the sentence 
 "...the bandwidth is more important that the exact shape..."
-
->>>>>>> upstream/master
 
 Page 357: In Equation 8.77 and 8.78 the term in square brackets should be squared. 
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Page 143: The pointers "upper panel" and "lower" panel in the caption for Figure
 
 ## Chapter 5
 
-Page 183: In Equation (5.17), the argument for the last exp is missing a minus sign. 
+Page 183: In Equation (5.17), the argument for the last exp is missing a minus sign.
 
 Page 188: In Equation (5.27) the labels of M should be swapped.  The correct
 equation is O_{21} = p(D|M_2)/p(D|M_1).
@@ -76,7 +76,7 @@ Page 309: In the gray box, the simulated data uses 1000 points in 2 dimensions, 
 
 ## Chapter 8
 
-Page 323: The y label in the bottom four panels in fig. 8.1 should be theta_0, and not theta_2. 
+Page 323: The y label in the bottom four panels in fig. 8.1 should be theta_0, and not theta_2.
 
 Page 326: Eq. 8.7 should start: "ln(L) \equiv ln(p(\theta|{x_i,y_i},I)) \propto \sum ...", i.e. the p inside ln is missing.
 
@@ -84,14 +84,16 @@ Page 328: Text reads "This is reflected in in the $\chi^2_{dof}$  for this fit  
 
 Page 329: The in-line comment on line 3 of the code snippet (the line begins with: X = np.random...) spills over to the next line and does not look like a comment anymore.
 
+Page 329: The last line of the preamble to the code box, "For data with *homoscedastic* errors..." should say *heteroscedastic* errors.
+
 Page 331: Line 3 in the code snippet is all a comment: "# dimension  dy = 0.1". The part "dy = 0.1" must be an instruction instead.
 
 Page 336: The caption of the code snippet reads "Ridge regression can be accomplished with the Lasso class in Skikit-learn:" This should be instead "Lasso regression can be accomplished ..."
 
-Page 339: Typo on line 7, "that" should be replaced by "than" in the sentence 
+Page 339: Typo on line 7, "that" should be replaced by "than" in the sentence
 "...the bandwidth is more important that the exact shape..."
 
-Page 357: In Equation 8.77 and 8.78 the term in square brackets should be squared. 
+Page 357: In Equation 8.77 and 8.78 the term in square brackets should be squared.
 
 ## Chapter 9
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Page 234: In the sample Python code, the sigma in the pymc.Normal command should
 
 ## Chapter 8
 
-
+Page 339: Typo on line 7, "...the bandwidth is more important that the exact shape..."
 
 ## Chapter 9
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Page 130: The denominator of the argument of the exponential of Eq. (4.11) shoul
 
 ## Chapter 5
 
+Page 183: In Equation (5.17), the argument for the last exp is missing a minus sign. 
+
 Page 188: In Equation (5.27) the labels of M should be swapped.  The correct
 equation is O_{21} = p(D|M_2)/p(D|M_1).
 


### PR DESCRIPTION
Sorry for the line feed corrections it seems to be wanting to make.  I suppose a git "cherry-pick" of the very last commit will avoid polluting the git log...