### PR TITLE
Added typo in Eqn 10.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Page 372: Equation 9.21 is missing a logarithm term. We should replace ``2\pi(\s
 
 
 ## Chapter 10
+Page 419: Equation 10.18 is missing the $dt$. It should read $H_w(t_0; f_0, Q) = \int_{-\infty}^{\infty} h(t) w(t | t_0, f_0, Q) dt$.
 
 Page 427: in the first paragraph of section 10.3.1, it should be
          omega = 2 pi f = 2 pi / P, and not (2 pi P) for the last part.


### PR DESCRIPTION
I added a typo to the list of errata in chapter 10. Specifically, there was a typo in equation 10.18 on p. 419, where $dt$ was missing at the end of the integral.