### PR TITLE
Added Figure 10.10 possible bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Page 372: Equation 9.21 is missing a logarithm term. We should replace ``2\pi(\s
 
 
 ## Chapter 10
+Page 419: Equation 10.18 is missing the $dt$. It should read $H_w(t_0; f_0, Q) = \int_{-\infty}^{\infty} h(t) w(t | t_0, f_0, Q) dt$.
 
 Page 427: in the first paragraph of section 10.3.1, it should be
          omega = 2 pi f = 2 pi / P, and not (2 pi P) for the last part.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Page 372: Equation 9.21 is missing a logarithm term. We should replace ``2\pi(\s
 ## Chapter 10
 Page 419: Equation 10.18 is missing the $dt$. It should read $H_w(t_0; f_0, Q) = \int_{-\infty}^{\infty} h(t) w(t | t_0, f_0, Q) dt$.
 
+Page 423: In the source code for Figure 10.10, the linewidth (lw) commands need to be removed to see the output from the call to ax.scatter. This means changing $ax.scatter(f[:N / 2], PSD[:N / 2], s=9, c='k', lw=0)$ to $ax.scatter(f[:N / 2], PSD[:N / 2], s=9, c='k')$, and $ax.scatter(f[:N / 2], filtered_PSD[:N / 2], s=9, c='k', lw=0)$ to $ax.scatter(f[:N / 2], filtered_PSD[:N / 2], s=9, c='k')$.
+
 Page 427: in the first paragraph of section 10.3.1, it should be
          omega = 2 pi f = 2 pi / P, and not (2 pi P) for the last part.
 


### PR DESCRIPTION
I could not reproduce Figure 10.10 using the available source code (http://www.astroml.org/book_figures/chapter10/fig_wiener_filter.html#book-fig-chapter10-fig-wiener-filter): the scatter points are not visible in the lower two panels. However, when I remove `, lw=0` from the two calls to ax.scatter (lines 91 and 109), it works as expected. Could this be due to a different version of matplotlib? I'm using 1.4.2.