### PR TITLE
Chapter 7 ICA

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ Page 266: Equation 6.21.  Summation index in the denominator should be k instead
 
 Page 309: In the gray box, the simulated data uses 1000 points in 2 dimensions, but the comments refer to 100 points in two dimensions.
 
+Page 314: Text around Equation 7.39 should read: "Two random variables are considered statistically independent if their joint probability distribution, f(x,y), can be fully described as the product of their marginalized probabilities, that is,
+
+  f(x,y) = f(x) f(y)
+  
+For the case of PCA, we find the weaker condition of uncorrelated data,
+
+  E(x y) = E(x) E(y),
+
+where E(.) is the expectation."
+
 ## Chapter 8
 
 Page 323: The y label in the bottom four panels in fig. 8.1 should be theta_0, and not theta_2.


### PR DESCRIPTION
Clarify the definitions of statistically independent or uncorrelated random variables.

I suspect that the original text was motivated by the fact that independent vars satisfy:

  E(x^p y^q) = E(x^p) E(y^p)

or, more generally,

  E(f(x) g(y)) = E(f(x)) E(g(y))

for any f, g bounded on their respective domains.  Uncorrelated vars then satisfy the same relation with p=q=1.